### PR TITLE
Allow \x and \v

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ that is that is designed to parse JSON written by humans
 
 - `/*` and `//` style comments.
 - Trailing commas for object and array literals.
+- `\v` and `\xDD` literal escapes (for vertical tab and
+  two-digit hexadecimal characters)
 - [planned] Unquoted object keys (precise spec TBD).
 
 I am still playing with the idea of making it more lenient,

--- a/src/de.rs
+++ b/src/de.rs
@@ -276,7 +276,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                                             self.eat_char();
                                             break;
                                         }
-                                        Some(_) => {},
+                                        Some(_) => {}
                                         None => {
                                             return Err(self.peek_error(
                                                 ErrorCode::EofWhileParsingBlockComment,
@@ -462,13 +462,11 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                             // number as a `u64` until we grow too large. At that point, switch to
                             // parsing the value as a `f64`.
                             if overflow!(res * 10 + digit, u64::max_value()) {
-                                return Ok(ParserNumber::F64(tri!(
-                                    self.parse_long_integer(
+                                return Ok(ParserNumber::F64(tri!(self.parse_long_integer(
                                     positive,
                                     res,
                                     1, // res * 10^1
-                                )
-                                )));
+                                ))));
                             }
 
                             res = res * 10 + digit;

--- a/tests/extra_escapes.rs
+++ b/tests/extra_escapes.rs
@@ -1,0 +1,19 @@
+extern crate serde;
+#[macro_use]
+extern crate serde_jsonrc;
+
+use serde_jsonrc::{from_str, Value};
+
+#[test]
+fn test_vertical_tab() {
+    let s = r#" { "key": "value\v" }"#;
+    let value: Value = from_str(&s).unwrap();
+    assert_eq!(value, json!({"key": "value\x0b"}));
+}
+
+#[test]
+fn test_two_digit_escape() {
+    let s = r#" { "key": "value\x0b" }"#;
+    let value: Value = from_str(&s).unwrap();
+    assert_eq!(value, json!({"key": "value\x0b"}));
+}


### PR DESCRIPTION
Here's a CL which would be useful for me, if you're willing to accept it.

Depends on #3 which is the merge of `serde_json` 1.0.45.
