### PR TITLE
Make all options switchable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ that is that is designed to parse JSON written by humans
 
 - `/*` and `//` style comments.
 - Trailing commas for object and array literals.
+- `\v` and `\xDD` literal escapes (for vertical tab and
+  two-digit hexadecimal characters)
 - [planned] Unquoted object keys (precise spec TBD).
 
 I am still playing with the idea of making it more lenient,

--- a/src/de.rs
+++ b/src/de.rs
@@ -276,7 +276,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                                             self.eat_char();
                                             break;
                                         }
-                                        Some(_) => {},
+                                        Some(_) => {}
                                         None => {
                                             return Err(self.peek_error(
                                                 ErrorCode::EofWhileParsingBlockComment,
@@ -462,13 +462,11 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                             // number as a `u64` until we grow too large. At that point, switch to
                             // parsing the value as a `f64`.
                             if overflow!(res * 10 + digit, u64::max_value()) {
-                                return Ok(ParserNumber::F64(tri!(
-                                    self.parse_long_integer(
+                                return Ok(ParserNumber::F64(tri!(self.parse_long_integer(
                                     positive,
                                     res,
                                     1, // res * 10^1
-                                )
-                                )));
+                                ))));
                             }
 
                             res = res * 10 + digit;

--- a/src/de.rs
+++ b/src/de.rs
@@ -1760,9 +1760,6 @@ impl<'de, 'a, R: Read<'de> + 'a> de::SeqAccess<'de> for SeqAccess<'a, R> {
                 // List most common branch first.
                 if b != b']' {
                     let result = Ok(Some(tri!(seed.deserialize(&mut *self.de))));
-                    if !result.is_ok() {
-                        return result;
-                    }
 
                     match tri!(self.de.parse_whitespace()) {
                         Some(b',') => self.de.eat_char(),

--- a/src/de.rs
+++ b/src/de.rs
@@ -82,13 +82,13 @@ where
 impl<'a> Deserializer<read::SliceRead<'a>> {
     /// Creates a JSON deserializer from a `&[u8]`.
     pub fn from_slice(bytes: &'a [u8]) -> Self {
-        Deserializer::new(read::SliceRead::new(bytes, false, false))
+        Deserializer::new(read::SliceRead::new(bytes, false, false, false, false))
     }
 
     /// Creates a JSON deserializer from a `&[u8]`,
     /// providing some flexibility for some non-standard JSON options.
-    pub fn from_slice_with_options(bytes: &'a [u8], replace_invalid_characters: bool, allow_control_characters_in_string: bool) -> Self {
-        Deserializer::new(read::SliceRead::new(bytes, replace_invalid_characters, allow_control_characters_in_string))
+    pub fn from_slice_with_options(bytes: &'a [u8], replace_invalid_characters: bool, allow_control_characters_in_string: bool, allow_v_escapes: bool, allow_x_escapes: bool) -> Self {
+        Deserializer::new(read::SliceRead::new(bytes, replace_invalid_characters, allow_control_characters_in_string, allow_v_escapes, allow_x_escapes))
     }
 }
 
@@ -2475,7 +2475,7 @@ pub fn from_slice<'a, T>(v: &'a [u8]) -> Result<T>
 where
     T: de::Deserialize<'a>,
 {
-    from_trait(read::SliceRead::new(v, false, false))
+    from_trait(read::SliceRead::new(v, false, false, false, false))
 }
 
 /// Deserialize an instance of type `T` from a string of JSON text.

--- a/src/de.rs
+++ b/src/de.rs
@@ -25,6 +25,7 @@ pub struct Deserializer<R> {
     remaining_depth: u8,
     #[cfg(feature = "unbounded_depth")]
     disable_recursion_limit: bool,
+    ignore_trailing_commas: bool,
 }
 
 impl<'de, R> Deserializer<R>
@@ -46,6 +47,7 @@ where
                 read: read,
                 scratch: Vec::new(),
                 remaining_depth: 128,
+                ignore_trailing_commas: true,
             }
         }
 
@@ -56,6 +58,7 @@ where
                 scratch: Vec::new(),
                 remaining_depth: 128,
                 disable_recursion_limit: false,
+                ignore_trailing_commas: true,
             }
         }
     }
@@ -202,6 +205,28 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     #[cfg(feature = "unbounded_depth")]
     pub fn disable_recursion_limit(&mut self) {
         self.disable_recursion_limit = true;
+    }
+
+    /// Whether to ignore trailing commas.
+    ///
+    /// By default, serde_jsonrc ignores trailing commas in its JSON input even
+    /// though this is not specification-compliant. This API allows the parser
+    /// to be switched to a strict mode in this respect, by passing `false` into
+    /// this API.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use serde_jsonrc::{Deserializer, Value};
+    /// use serde::de::Deserialize;
+    ///
+    /// let s = r#" { "a", "b", }"#;
+    /// let mut deserializer = Deserializer::from_str(&s);
+    /// deserializer.set_ignore_trailing_commas(false);
+    /// assert!(Value::deserialize(&mut deserializer).is_err());
+    /// ```
+    pub fn set_ignore_trailing_commas(&mut self, ignore: bool) {
+        self.ignore_trailing_commas = ignore;
     }
 
     fn peek(&mut self) -> Result<Option<u8>> {
@@ -1740,11 +1765,15 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
 
 struct SeqAccess<'a, R: 'a> {
     de: &'a mut Deserializer<R>,
+    first: bool,
 }
 
 impl<'a, R: 'a> SeqAccess<'a, R> {
     fn new(de: &'a mut Deserializer<R>) -> Self {
-        SeqAccess { de }
+        SeqAccess {
+            de: de,
+            first: true,
+        }
     }
 }
 
@@ -1755,41 +1784,74 @@ impl<'de, 'a, R: Read<'de> + 'a> de::SeqAccess<'de> for SeqAccess<'a, R> {
     where
         T: de::DeserializeSeed<'de>,
     {
-        match tri!(self.de.parse_whitespace()) {
-            Some(b) => {
-                // List most common branch first.
-                if b != b']' {
-                    let result = Ok(Some(tri!(seed.deserialize(&mut *self.de))));
+        if self.de.ignore_trailing_commas {
+            match tri!(self.de.parse_whitespace()) {
+                Some(b) => {
+                    // List most common branch first.
+                    if b != b']' {
+                        let result = Ok(Some(tri!(seed.deserialize(&mut *self.de))));
 
-                    match tri!(self.de.parse_whitespace()) {
-                        Some(b',') => self.de.eat_char(),
-                        Some(b']') => {
-                            // Ignore.
+                        match tri!(self.de.parse_whitespace()) {
+                            Some(b',') => self.de.eat_char(),
+                            Some(b']') => {
+                                // Ignore.
+                            }
+                            Some(_) => {
+                                return Err(self.de.peek_error(ErrorCode::ExpectedListCommaOrEnd));
+                            }
+                            None => {
+                                return Err(self.de.peek_error(ErrorCode::EofWhileParsingList));
+                            }
                         }
-                        Some(_) => {
-                            return Err(self.de.peek_error(ErrorCode::ExpectedListCommaOrEnd));
-                        }
-                        None => {
-                            return Err(self.de.peek_error(ErrorCode::EofWhileParsingList));
-                        }
+                        result
+                    } else {
+                        Ok(None)
                     }
-                    result
-                } else {
-                    Ok(None)
                 }
+                None => Err(self.de.peek_error(ErrorCode::EofWhileParsingList)),
             }
-            None => Err(self.de.peek_error(ErrorCode::EofWhileParsingList)),
+        } else {
+            let peek = match tri!(self.de.parse_whitespace()) {
+                Some(b']') => {
+                    return Ok(None);
+                }
+                Some(b',') if !self.first => {
+                    self.de.eat_char();
+                    tri!(self.de.parse_whitespace())
+                }
+                Some(b) => {
+                    if self.first {
+                        self.first = false;
+                        Some(b)
+                    } else {
+                        return Err(self.de.peek_error(ErrorCode::ExpectedListCommaOrEnd));
+                    }
+                }
+                None => {
+                    return Err(self.de.peek_error(ErrorCode::EofWhileParsingList));
+                }
+            };
+
+            match peek {
+                Some(b']') => Err(self.de.peek_error(ErrorCode::TrailingComma)),
+                Some(_) => Ok(Some(tri!(seed.deserialize(&mut *self.de)))),
+                None => Err(self.de.peek_error(ErrorCode::EofWhileParsingValue)),
+            }
         }
     }
 }
 
 struct MapAccess<'a, R: 'a> {
     de: &'a mut Deserializer<R>,
+    first: bool,
 }
 
 impl<'a, R: 'a> MapAccess<'a, R> {
     fn new(de: &'a mut Deserializer<R>) -> Self {
-        MapAccess { de }
+        MapAccess {
+            de: de,
+            first: true,
+        }
     }
 }
 
@@ -1800,13 +1862,43 @@ impl<'de, 'a, R: Read<'de> + 'a> de::MapAccess<'de> for MapAccess<'a, R> {
     where
         K: de::DeserializeSeed<'de>,
     {
-        match tri!(self.de.parse_whitespace()) {
-            Some(b'"') => seed.deserialize(MapKey { de: &mut *self.de }).map(Some),
-            Some(b'}') => {
-                return Ok(None);
+        if self.de.ignore_trailing_commas {
+            match tri!(self.de.parse_whitespace()) {
+                Some(b'"') => seed.deserialize(MapKey { de: &mut *self.de }).map(Some),
+                Some(b'}') => {
+                    return Ok(None);
+                }
+                Some(_) => Err(self.de.peek_error(ErrorCode::KeyMustBeAString)),
+                None => Err(self.de.peek_error(ErrorCode::EofWhileParsingObject)),
             }
-            Some(_) => Err(self.de.peek_error(ErrorCode::KeyMustBeAString)),
-            None => Err(self.de.peek_error(ErrorCode::EofWhileParsingObject)),
+        } else {
+            let peek = match tri!(self.de.parse_whitespace()) {
+                Some(b'}') => {
+                    return Ok(None);
+                }
+                Some(b',') if !self.first => {
+                    self.de.eat_char();
+                    tri!(self.de.parse_whitespace())
+                }
+                Some(b) => {
+                    if self.first {
+                        self.first = false;
+                        Some(b)
+                    } else {
+                        return Err(self.de.peek_error(ErrorCode::ExpectedObjectCommaOrEnd));
+                    }
+                }
+                None => {
+                    return Err(self.de.peek_error(ErrorCode::EofWhileParsingObject));
+                }
+            };
+
+            match peek {
+                Some(b'"') => seed.deserialize(MapKey { de: &mut *self.de }).map(Some),
+                Some(b'}') => Err(self.de.peek_error(ErrorCode::TrailingComma)),
+                Some(_) => Err(self.de.peek_error(ErrorCode::KeyMustBeAString)),
+                None => Err(self.de.peek_error(ErrorCode::EofWhileParsingValue)),
+            }
         }
     }
 
@@ -1814,23 +1906,29 @@ impl<'de, 'a, R: Read<'de> + 'a> de::MapAccess<'de> for MapAccess<'a, R> {
     where
         V: de::DeserializeSeed<'de>,
     {
-        tri!(self.de.parse_object_colon());
-        let result = seed.deserialize(&mut *self.de);
-        if result.is_ok() {
-            match tri!(self.de.parse_whitespace()) {
-                Some(b',') => self.de.eat_char(),
-                Some(b'}') => {
-                    // Ignore.
-                }
-                Some(_) => {
-                    return Err(self.de.peek_error(ErrorCode::ExpectedObjectCommaOrEnd));
-                }
-                None => {
-                    return Err(self.de.peek_error(ErrorCode::EofWhileParsingObject));
-                }
+        if self.de.ignore_trailing_commas {
+            tri!(self.de.parse_object_colon());
+            let result = seed.deserialize(&mut *self.de);
+            if result.is_ok() {
+                match tri!(self.de.parse_whitespace()) {
+                    Some(b',') => self.de.eat_char(),
+                    Some(b'}') => {
+                        // Ignore.
+                    }
+                    Some(_) => {
+                        return Err(self.de.peek_error(ErrorCode::ExpectedObjectCommaOrEnd));
+                    }
+                    None => {
+                        return Err(self.de.peek_error(ErrorCode::EofWhileParsingObject));
+                    }
+                };
             };
-        };
-        result
+            result
+        } else {
+            tri!(self.de.parse_object_colon());
+
+            seed.deserialize(&mut *self.de)
+        }
     }
 }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -79,7 +79,13 @@ where
 impl<'a> Deserializer<read::SliceRead<'a>> {
     /// Creates a JSON deserializer from a `&[u8]`.
     pub fn from_slice(bytes: &'a [u8]) -> Self {
-        Deserializer::new(read::SliceRead::new(bytes))
+        Deserializer::new(read::SliceRead::new(bytes, false))
+    }
+
+    /// Creates a JSON deserializer from a `&[u8]`,
+    /// replacing invalid characters.
+    pub fn from_slice_replacing_invalid_characters(bytes: &'a [u8]) -> Self {
+        Deserializer::new(read::SliceRead::new(bytes, true))
     }
 }
 
@@ -2376,7 +2382,7 @@ pub fn from_slice<'a, T>(v: &'a [u8]) -> Result<T>
 where
     T: de::Deserialize<'a>,
 {
-    from_trait(read::SliceRead::new(v))
+    from_trait(read::SliceRead::new(v, false))
 }
 
 /// Deserialize an instance of type `T` from a string of JSON text.

--- a/src/de.rs
+++ b/src/de.rs
@@ -82,13 +82,13 @@ where
 impl<'a> Deserializer<read::SliceRead<'a>> {
     /// Creates a JSON deserializer from a `&[u8]`.
     pub fn from_slice(bytes: &'a [u8]) -> Self {
-        Deserializer::new(read::SliceRead::new(bytes, false))
+        Deserializer::new(read::SliceRead::new(bytes, false, false))
     }
 
     /// Creates a JSON deserializer from a `&[u8]`,
-    /// replacing invalid characters.
-    pub fn from_slice_replacing_invalid_characters(bytes: &'a [u8]) -> Self {
-        Deserializer::new(read::SliceRead::new(bytes, true))
+    /// providing some flexibility for some non-standard JSON options.
+    pub fn from_slice_with_options(bytes: &'a [u8], replace_invalid_characters: bool, allow_control_characters_in_string: bool) -> Self {
+        Deserializer::new(read::SliceRead::new(bytes, replace_invalid_characters, allow_control_characters_in_string))
     }
 }
 
@@ -2475,7 +2475,7 @@ pub fn from_slice<'a, T>(v: &'a [u8]) -> Result<T>
 where
     T: de::Deserialize<'a>,
 {
-    from_trait(read::SliceRead::new(v, false))
+    from_trait(read::SliceRead::new(v, false, false))
 }
 
 /// Deserialize an instance of type `T` from a string of JSON text.

--- a/src/de.rs
+++ b/src/de.rs
@@ -26,6 +26,7 @@ pub struct Deserializer<R> {
     #[cfg(feature = "unbounded_depth")]
     disable_recursion_limit: bool,
     ignore_trailing_commas: bool,
+    allow_comments: bool,
 }
 
 impl<'de, R> Deserializer<R>
@@ -48,6 +49,7 @@ where
                 scratch: Vec::new(),
                 remaining_depth: 128,
                 ignore_trailing_commas: true,
+                allow_comments: true,
             }
         }
 
@@ -59,6 +61,7 @@ where
                 remaining_depth: 128,
                 disable_recursion_limit: false,
                 ignore_trailing_commas: true,
+                allow_comments: true,
             }
         }
     }
@@ -235,6 +238,11 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         self.ignore_trailing_commas = ignore;
     }
 
+    /// Whether to allow comments.
+    pub fn set_allow_comments(&mut self, allow: bool) {
+        self.allow_comments = allow;
+    }
+
     fn peek(&mut self) -> Result<Option<u8>> {
         self.read.peek()
     }
@@ -278,7 +286,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                 Some(b' ') | Some(b'\n') | Some(b'\t') | Some(b'\r') => {
                     self.eat_char();
                 }
-                Some(b'/') => {
+                Some(b'/') if self.allow_comments => {
                     self.eat_char();
                     match tri!(self.peek()) {
                         Some(b'/') => {

--- a/src/read.rs
+++ b/src/read.rs
@@ -679,10 +679,12 @@ impl<'a> Read<'a> for StrRead<'a> {
 
 //////////////////////////////////////////////////////////////////////////////
 
+const ALLOW_CONTROL_CHARACTERS_IN_STRING: bool = false;
+
 // Lookup table of bytes that must be escaped. A value of true at index i means
 // that byte i requires an escape sequence in the input.
 static ESCAPE: [bool; 256] = {
-    const CT: bool = true; // control character \x00..=\x1F
+    const CT: bool = ALLOW_CONTROL_CHARACTERS_IN_STRING; // control character \x00..=\x1F
     const QU: bool = true; // quote \x22
     const BS: bool = true; // backslash \x5C
     const __: bool = false; // allow unescaped

--- a/src/read.rs
+++ b/src/read.rs
@@ -120,6 +120,42 @@ impl<'b, 'c, T: ?Sized + 'static> Deref for Reference<'b, 'c, T> {
     }
 }
 
+/// Trait used by parse_str_bytes to convert the resulting bytes
+/// into a string-like thing. Depending on the original caller, this may
+/// be a &str or a $[u8].
+trait UtfOutputStrategy<'s, T>
+where
+    T: 's,
+{
+    fn to_result<'de, R: Read<'de>>(&self, read: &R, slice: &'s [u8]) -> Result<T>;
+}
+
+struct StrUtfOutputStrategy;
+
+impl<'s> UtfOutputStrategy<'s, &'s str> for StrUtfOutputStrategy {
+    fn to_result<'de, R: Read<'de>>(&self, read: &R, slice: &'s [u8]) -> Result<&'s str> {
+        str::from_utf8(slice).or_else(|_| error(read, ErrorCode::InvalidUnicodeCodePoint))
+    }
+}
+
+struct UncheckedStrUtfOutputStrategy;
+
+impl<'s> UtfOutputStrategy<'s, &'s str> for UncheckedStrUtfOutputStrategy {
+    fn to_result<'de, R: Read<'de>>(&self, _: &R, slice: &'s [u8]) -> Result<&'s str> {
+        // The input is assumed to be valid UTF-8 and the \u-escapes are
+        // checked along the way, so don't need to check here.
+        Ok(unsafe { str::from_utf8_unchecked(slice) })
+    }
+}
+
+struct SliceUtfOutputStrategy;
+
+impl<'s> UtfOutputStrategy<'s, &'s [u8]> for SliceUtfOutputStrategy {
+    fn to_result<'de, R: Read<'de>>(&self, _: &R, slice: &'s [u8]) -> Result<&'s [u8]> {
+        Ok(slice)
+    }
+}
+
 /// JSON input source that reads from a std::io input stream.
 #[cfg(feature = "std")]
 pub struct IoRead<R>
@@ -194,15 +230,15 @@ impl<R> IoRead<R>
 where
     R: io::Read,
 {
-    fn parse_str_bytes<'s, T, F>(
+    fn parse_str_bytes<'s, T, S>(
         &'s mut self,
         scratch: &'s mut Vec<u8>,
         validate: bool,
-        result: F,
+        utf_strategy: S,
     ) -> Result<T>
     where
         T: 's,
-        F: FnOnce(&'s Self, &'s [u8]) -> Result<T>,
+        S: UtfOutputStrategy<'s, T>,
     {
         loop {
             let ch = tri!(next_or_eof(self));
@@ -212,7 +248,7 @@ where
             }
             match ch {
                 b'"' => {
-                    return result(self, scratch);
+                    return utf_strategy.to_result(self, scratch);
                 }
                 b'\\' => {
                     tri!(parse_escape(self, scratch));
@@ -312,7 +348,7 @@ where
     }
 
     fn parse_str<'s>(&'s mut self, scratch: &'s mut Vec<u8>) -> Result<Reference<'de, 's, str>> {
-        self.parse_str_bytes(scratch, true, as_str)
+        self.parse_str_bytes(scratch, true, StrUtfOutputStrategy)
             .map(Reference::Copied)
     }
 
@@ -320,7 +356,7 @@ where
         &'s mut self,
         scratch: &'s mut Vec<u8>,
     ) -> Result<Reference<'de, 's, [u8]>> {
-        self.parse_str_bytes(scratch, false, |_, bytes| Ok(bytes))
+        self.parse_str_bytes(scratch, false, SliceUtfOutputStrategy)
             .map(Reference::Copied)
     }
 
@@ -416,15 +452,15 @@ impl<'a> SliceRead<'a> {
     /// The big optimization here over IoRead is that if the string contains no
     /// backslash escape sequences, the returned &str is a slice of the raw JSON
     /// data so we avoid copying into the scratch space.
-    fn parse_str_bytes<'s, T: ?Sized, F>(
+    fn parse_str_bytes<'s, T: ?Sized, S>(
         &'s mut self,
         scratch: &'s mut Vec<u8>,
         validate: bool,
-        result: F,
+        utf_strategy: S,
     ) -> Result<Reference<'a, 's, T>>
     where
         T: 's,
-        F: for<'f> FnOnce(&'s Self, &'f [u8]) -> Result<&'f T>,
+        S: for<'f> UtfOutputStrategy<'f, &'f T>,
     {
         // Index of the first byte not yet copied into the scratch space.
         let mut start = self.index;
@@ -443,11 +479,13 @@ impl<'a> SliceRead<'a> {
                         // copying.
                         let borrowed = &self.slice[start..self.index];
                         self.index += 1;
-                        return result(self, borrowed).map(Reference::Borrowed);
+                        return utf_strategy
+                            .to_result(self, borrowed)
+                            .map(Reference::Borrowed);
                     } else {
                         scratch.extend_from_slice(&self.slice[start..self.index]);
                         self.index += 1;
-                        return result(self, scratch).map(Reference::Copied);
+                        return utf_strategy.to_result(self, scratch).map(Reference::Copied);
                     }
                 }
                 b'\\' => {
@@ -514,14 +552,14 @@ impl<'a> Read<'a> for SliceRead<'a> {
     }
 
     fn parse_str<'s>(&'s mut self, scratch: &'s mut Vec<u8>) -> Result<Reference<'a, 's, str>> {
-        self.parse_str_bytes(scratch, true, as_str)
+        self.parse_str_bytes(scratch, true, StrUtfOutputStrategy)
     }
 
     fn parse_str_raw<'s>(
         &'s mut self,
         scratch: &'s mut Vec<u8>,
     ) -> Result<Reference<'a, 's, [u8]>> {
-        self.parse_str_bytes(scratch, false, |_, bytes| Ok(bytes))
+        self.parse_str_bytes(scratch, false, SliceUtfOutputStrategy)
     }
 
     fn ignore_str(&mut self) -> Result<()> {
@@ -638,11 +676,8 @@ impl<'a> Read<'a> for StrRead<'a> {
     }
 
     fn parse_str<'s>(&'s mut self, scratch: &'s mut Vec<u8>) -> Result<Reference<'a, 's, str>> {
-        self.delegate.parse_str_bytes(scratch, true, |_, bytes| {
-            // The input is assumed to be valid UTF-8 and the \u-escapes are
-            // checked along the way, so don't need to check here.
-            Ok(unsafe { str::from_utf8_unchecked(bytes) })
-        })
+        self.delegate
+            .parse_str_bytes(scratch, true, UncheckedStrUtfOutputStrategy)
     }
 
     fn parse_str_raw<'s>(
@@ -717,10 +752,6 @@ fn next_or_eof<'de, R: ?Sized + Read<'de>>(read: &mut R) -> Result<u8> {
 fn error<'de, R: ?Sized + Read<'de>, T>(read: &R, reason: ErrorCode) -> Result<T> {
     let position = read.position();
     Err(Error::syntax(reason, position.line, position.column))
-}
-
-fn as_str<'de, 's, R: Read<'de>>(read: &R, slice: &'s [u8]) -> Result<&'s str> {
-    str::from_utf8(slice).or_else(|_| error(read, ErrorCode::InvalidUnicodeCodePoint))
 }
 
 /// Parses a JSON escape sequence and appends it into the scratch space. Assumes

--- a/tests/control_characters.rs
+++ b/tests/control_characters.rs
@@ -1,0 +1,13 @@
+extern crate serde;
+
+#[macro_use]
+extern crate serde_jsonrc;
+
+use serde_jsonrc::{from_str, Value};
+
+#[test]
+fn test_control_character() {
+    let s = "{ \"key\": \"a\0b\nc\" }";
+    let value: Value = from_str(s).unwrap();
+    assert_eq!(value, json!({"key": "a\0b\nc"}));
+}

--- a/tests/extra_escapes.rs
+++ b/tests/extra_escapes.rs
@@ -1,0 +1,19 @@
+extern crate serde;
+#[macro_use]
+extern crate serde_jsonrc;
+
+use serde_jsonrc::{from_str, Value};
+
+#[test]
+fn test_vertical_tab() {
+    let s = r#" { "key": "value\v" }"#;
+    let value: Value = from_str(&s).unwrap();
+    assert_eq!(value, json!({"key": "value\x0b"}));
+}
+
+#[test]
+fn test_two_digit_escape() {
+    let s = r#" { "key": "value\x0b" }"#;
+    let value: Value = from_str(&s).unwrap();
+    assert_eq!(value, json!({"key": "value\x0b"}));
+}

--- a/tests/invalid_characters.rs
+++ b/tests/invalid_characters.rs
@@ -1,0 +1,35 @@
+extern crate serde;
+
+#[macro_use]
+extern crate serde_jsonrc;
+
+use serde_jsonrc::{Value, Deserializer, Error};
+use serde_jsonrc::de::SliceRead;
+use serde::de::Deserialize;
+
+fn from_slice_with_unicode_substitution(s: &[u8]) -> Result<Value, Error> {
+    let mut de = Deserializer::new(SliceRead::new(s, true));
+    Deserialize::deserialize(&mut de)
+}
+
+#[test]
+fn test_invalid_characters() {
+    let prefix = r#" { "key": "value"#;
+    let suffix = r#"" }"#;
+    let mut s: Vec<u8> = vec![];
+    s.extend(prefix.as_bytes());
+    s.extend(&[0xed, 0xa0, 0x80]);
+    s.extend(suffix.as_bytes());
+    let value = from_slice_with_unicode_substitution(&s).unwrap();
+    assert_eq!(value, json!({"key": "value\u{fffd}\u{fffd}\u{fffd}"}));
+}
+
+#[test]
+fn test_invalid_utf16_escape_sequence() {
+    let s = r#"
+    {
+        "key": "value\ud800"
+    }"#.as_bytes();
+    let value: Value = from_slice_with_unicode_substitution(&s).unwrap();
+    assert_eq!(value, json!({"key": "value\u{fffd}"}));
+}

--- a/tests/invalid_characters.rs
+++ b/tests/invalid_characters.rs
@@ -8,7 +8,7 @@ use serde_jsonrc::de::SliceRead;
 use serde::de::Deserialize;
 
 fn from_slice_with_unicode_substitution(s: &[u8]) -> Result<Value, Error> {
-    let mut de = Deserializer::new(SliceRead::new(s, true, false));
+    let mut de = Deserializer::new(SliceRead::new(s, true, false, false, false));
     Deserialize::deserialize(&mut de)
 }
 

--- a/tests/invalid_characters.rs
+++ b/tests/invalid_characters.rs
@@ -8,7 +8,7 @@ use serde_jsonrc::de::SliceRead;
 use serde::de::Deserialize;
 
 fn from_slice_with_unicode_substitution(s: &[u8]) -> Result<Value, Error> {
-    let mut de = Deserializer::new(SliceRead::new(s, true));
+    let mut de = Deserializer::new(SliceRead::new(s, true, false));
     Deserialize::deserialize(&mut de)
 }
 

--- a/tests/non_characters.rs
+++ b/tests/non_characters.rs
@@ -1,0 +1,16 @@
+extern crate serde;
+
+#[macro_use]
+extern crate serde_jsonrc;
+
+use serde_jsonrc::{from_str, Value};
+
+#[test]
+fn test_non_character() {
+    let s = r#"
+    {
+        "key": "value\ufdef\uffff"
+    }"#;
+    let value: Value = from_str(s).unwrap();
+    assert_eq!(value, json!({"key": "value\u{fffd}\u{fffd}"}));
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -973,14 +973,6 @@ fn test_parse_string() {
             "\"\\uD83C\\uFFFF\"",
             "lone leading surrogate in hex escape at line 1 column 13",
         ),
-        (
-            "\"\n\"",
-            "control character (\\u0000-\\u001F) found while parsing a string at line 2 column 0",
-        ),
-        (
-            "\"\x1F\"",
-            "control character (\\u0000-\\u001F) found while parsing a string at line 1 column 2",
-        ),
     ]);
 
     test_parse_slice_err::<String>(&[
@@ -1011,14 +1003,6 @@ fn test_parse_string() {
         (
             &[b'"', b'\\', b'u', 48, 48, 51, 250, b'"'],
             "invalid escape at line 1 column 7",
-        ),
-        (
-            &[b'"', b'\n', b'"'],
-            "control character (\\u0000-\\u001F) found while parsing a string at line 2 column 0",
-        ),
-        (
-            &[b'"', b'\x1F', b'"'],
-            "control character (\\u0000-\\u001F) found while parsing a string at line 1 column 2",
         ),
     ]);
 

--- a/tests/trailing_comma.rs
+++ b/tests/trailing_comma.rs
@@ -6,7 +6,8 @@ extern crate serde;
 #[macro_use]
 extern crate serde_jsonrc;
 
-use serde_jsonrc::{from_str, Value};
+use serde::Deserialize;
+use serde_jsonrc::{from_str, Deserializer, Value};
 
 #[test]
 fn test_trailing_comma_object() {
@@ -111,4 +112,21 @@ fn test_parse_enum_as_object_with_deny_unknown_fields() {
             name: "Kate".to_string()
         }
     );
+}
+
+#[test]
+fn test_commas_switchable() {
+    let s = r#"
+    {
+        "key": "value",
+    }"#;
+    let mut deserializer = Deserializer::from_str(&s);
+    deserializer.set_ignore_trailing_commas(false);
+    assert!(Value::deserialize(&mut deserializer)
+        .unwrap_err()
+        .to_string()
+        .contains("comma"));
+    let mut deserializer = Deserializer::from_str(&s);
+    let value = Value::deserialize(&mut deserializer).unwrap();
+    assert_eq!(value, json!({ "key": "value" }));
 }


### PR DESCRIPTION
This is a PR representing all our changes against `serde_jsonrc`. This includes some changes represented in other `serde_jsonrc` PRs #4, #5 and #6, but additionally makes _all_ of serde_jsonrc's extensions switchable.